### PR TITLE
Added an empty set_options() for ans 2.9

### DIFF
--- a/ansible/callback_plugins/profile_tasks.py
+++ b/ansible/callback_plugins/profile_tasks.py
@@ -69,3 +69,6 @@ class CallbackModule(object):
                 datetime.timedelta(seconds=(int(total_seconds)))
                 )
           )
+
+    def set_options(self):
+        None


### PR DESCRIPTION
This enables the ipa/setup.sh to run and provision machines. Probably not the best solution but it is a small amount of progress.